### PR TITLE
Improve scheduling support

### DIFF
--- a/src/FacebookPosterPost.php
+++ b/src/FacebookPosterPost.php
@@ -2,7 +2,7 @@
 
 namespace NotificationChannels\FacebookPoster;
 
-use DateTime;
+use DateTimeInterface;
 use NotificationChannels\FacebookPoster\Attachments\Link;
 use NotificationChannels\FacebookPoster\Attachments\Image;
 use NotificationChannels\FacebookPoster\Attachments\Video;
@@ -102,11 +102,12 @@ class FacebookPosterPost
      *
      * @param string $timestamp UNIX timestamp
      *
+     * @param  \DateTimeInterface|int  $timestamp
      * @return $this
      */
     public function scheduledFor($timestamp)
     {
-        $timestamp = $timestamp instanceof DateTime
+        $timestamp = $timestamp instanceof DateTimeInterface
             ? $timestamp->getTimestamp()
             : $timestamp;
 

--- a/src/FacebookPosterPost.php
+++ b/src/FacebookPosterPost.php
@@ -2,6 +2,7 @@
 
 namespace NotificationChannels\FacebookPoster;
 
+use DateTime;
 use NotificationChannels\FacebookPoster\Attachments\Link;
 use NotificationChannels\FacebookPoster\Attachments\Image;
 use NotificationChannels\FacebookPoster\Attachments\Video;
@@ -105,6 +106,10 @@ class FacebookPosterPost
      */
     public function scheduledFor($timestamp)
     {
+        $timestamp = $timestamp instanceof DateTime
+            ? $timestamp->getTimestamp()
+            : $timestamp;
+
         $this->params['published'] = false;
         $this->params['scheduled_publish_time'] = $timestamp;
 

--- a/tests/FacebookPosterPostTest.php
+++ b/tests/FacebookPosterPostTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace NotificationChannels\FacebookPoster\Test;
+
+use DateTime;
+use Orchestra\Testbench\TestCase;
+use NotificationChannels\FacebookPoster\FacebookPosterPost;
+
+class FacebookPosterPostTest extends TestCase
+{
+    /** @test */
+    public function it_can_be_scheduled()
+    {
+        $post = new FacebookPosterPost('Test');
+
+        $post->scheduledFor(1234);
+
+        $result = $post->getPostBody();
+
+        $this->assertEquals([
+            'message' => 'Test',
+            'published' => false,
+            'scheduled_publish_time' => 1234,
+        ], $result);
+    }
+
+    /** @test */
+    public function it_can_be_scheduled_with_datetime()
+    {
+        $post = new FacebookPosterPost('Test');
+
+        $post->scheduledFor(new DateTime('2000-01-01'));
+
+        $result = $post->getPostBody();
+
+        $this->assertEquals([
+            'message' => 'Test',
+            'published' => false,
+            'scheduled_publish_time' => 946684800,
+        ], $result);
+    }
+}

--- a/tests/FacebookPosterPostTest.php
+++ b/tests/FacebookPosterPostTest.php
@@ -3,6 +3,7 @@
 namespace NotificationChannels\FacebookPoster\Test;
 
 use DateTime;
+use DateTimeImmutable;
 use Orchestra\Testbench\TestCase;
 use NotificationChannels\FacebookPoster\FacebookPosterPost;
 
@@ -30,6 +31,22 @@ class FacebookPosterPostTest extends TestCase
         $post = new FacebookPosterPost('Test');
 
         $post->scheduledFor(new DateTime('2000-01-01'));
+
+        $result = $post->getPostBody();
+
+        $this->assertEquals([
+            'message' => 'Test',
+            'published' => false,
+            'scheduled_publish_time' => 946684800,
+        ], $result);
+    }
+
+    /** @test */
+    public function it_can_be_scheduled_with_immutable_datetime()
+    {
+        $post = new FacebookPosterPost('Test');
+
+        $post->scheduledFor(new DateTimeImmutable('2000-01-01'));
 
         $result = $post->getPostBody();
 


### PR DESCRIPTION
This improves the scheduler method to support accepting an instance of `DateTime` (and therefore Carbon, which is probably more likely in a Laravel app) as a way to pass in a scheduled time.