### PR TITLE
Improve Mockery integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "illuminate/support": "~5.5 || ~6.0"
     },
     "require-dev": {
-        "mockery/mockery": "^0.9.5",
+        "mockery/mockery": "~1.0",
         "orchestra/testbench": "~3.7 || ~4.0",
         "phpunit/phpunit": "~7.0 || ~8.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require-dev": {
         "mockery/mockery": "~1.0",
         "orchestra/testbench": "~3.7 || ~4.0",
-        "phpunit/phpunit": "~7.0 || ~8.0"
+        "phpunit/phpunit": "~8.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
         "illuminate/support": "~5.5 || ~6.0"
     },
     "require-dev": {
-        "mockery/mockery": "~1.0",
-        "orchestra/testbench": "~3.7 || ~4.0",
+        "mockery/mockery": "~1.2.1",
+        "orchestra/testbench": "~4.0",
         "phpunit/phpunit": "~8.0"
     },
     "autoload": {

--- a/tests/FacebookPosterChannelTest.php
+++ b/tests/FacebookPosterChannelTest.php
@@ -4,7 +4,6 @@ namespace NotificationChannels\FacebookPoster\Test;
 
 use Mockery;
 use Facebook\Facebook;
-use Orchestra\Testbench\TestCase;
 use Illuminate\Notifications\Notification;
 use NotificationChannels\FacebookPoster\FacebookPosterChannel;
 

--- a/tests/FacebookPosterChannelTest.php
+++ b/tests/FacebookPosterChannelTest.php
@@ -4,7 +4,6 @@ namespace NotificationChannels\FacebookPoster\Test;
 
 use Mockery;
 use Facebook\Facebook;
-use Illuminate\Notifications\Notification;
 use NotificationChannels\FacebookPoster\FacebookPosterChannel;
 
 class FacebookPosterChannelTest extends TestCase

--- a/tests/FacebookPosterChannelTest.php
+++ b/tests/FacebookPosterChannelTest.php
@@ -14,18 +14,12 @@ class FacebookPosterChannelTest extends TestCase
     /** @var \NotificationChannels\FacebookPoster\FacebookPosterChannel */
     protected $channel;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
         $this->facebook = Mockery::mock(Facebook::class);
         $this->channel = new FacebookPosterChannel($this->facebook);
-    }
-
-    public function tearDown()
-    {
-        Mockery::close();
-        parent::tearDown();
     }
 
     /** @test */

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,8 +2,8 @@
 
 namespace NotificationChannels\FacebookPoster\Test;
 
-use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Orchestra\Testbench\TestCase as BaseTestCase;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 
 class TestCase extends BaseTestCase
 {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace NotificationChannels\FacebookPoster\Test;
+
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Orchestra\Testbench\TestCase as BaseTestCase;
+
+class TestCase extends BaseTestCase
+{
+    use MockeryPHPUnitIntegration;
+}


### PR DESCRIPTION
Our current test suite doesn't actually perform assertions with Mockery expectations.

This adds a base test case that includes the Mockery PHPUnit integration trait that will fix the PHPUnit warnings that there are no assertions.

```
PHPUnit 7.5.16 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.3.9
Configuration: /Users/dwight/Sites/facebook-poster/phpunit.xml.dist
Error:         No code coverage driver is available

RRRR                                                                4 / 4 (100%)

Time: 100 ms, Memory: 12.00 MB

There were 4 risky tests:

1) NotificationChannels\FacebookPoster\Test\FacebookPosterChannelTest::it_can_send_a_post
This test did not perform any assertions

/Users/dwight/Sites/facebook-poster/tests/FacebookPosterChannelTest.php:34

2) NotificationChannels\FacebookPoster\Test\FacebookPosterChannelTest::it_can_send_a_post_with_link
This test did not perform any assertions

/Users/dwight/Sites/facebook-poster/tests/FacebookPosterChannelTest.php:45

3) NotificationChannels\FacebookPoster\Test\FacebookPosterChannelTest::it_can_send_a_post_with_image
This test did not perform any assertions

/Users/dwight/Sites/facebook-poster/tests/FacebookPosterChannelTest.php:56

4) NotificationChannels\FacebookPoster\Test\FacebookPosterChannelTest::it_can_send_a_post_with_video
This test did not perform any assertions

/Users/dwight/Sites/facebook-poster/tests/FacebookPosterChannelTest.php:66
```