### PR TITLE
Rename configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ You will need to [create](https://developers.facebook.com/apps) a Facebook app i
 ```php
 ...
 'facebook_poster' => [
-	'app_id' => getenv('FACEBOOK_APP_ID'),
-	'app_secret' => getenv('FACEBOOK_APP_SECRET'),
+	'client_id' => getenv('FACEBOOK_APP_ID'),
+	'client_secret' => getenv('FACEBOOK_APP_SECRET'),
 	'access_token' => getenv('FACEBOOK_ACCESS_TOKEN'),
 ],
 ...

--- a/src/FacebookPosterServiceProvider.php
+++ b/src/FacebookPosterServiceProvider.php
@@ -16,8 +16,8 @@ class FacebookPosterServiceProvider extends ServiceProvider
             ->needs(Facebook::class)
             ->give(function ($app) {
                 return new Facebook([
-                    'app_id' => $app['config']['services.facebook_poster.app_id'],
-                    'app_secret' => $app['config']['services.facebook_poster.app_secret'],
+                    'app_id' => $app['config']['services.facebook_poster.client_id'],
+                    'app_secret' => $app['config']['services.facebook_poster.client_secret'],
                     'default_access_token' => $app['config']['services.facebook_poster.access_token'],
                 ]);
             });


### PR DESCRIPTION
We currently use `app_id` and `app_secret` as configuration option names, which does make sense as they are the names Facebook uses, but I wonder if perhaps we'd be best to match the naming scheme of the Socialite channels.

Here's how it would look right now if you used Socialite and this package together, which I think just looks a little odd and inconsistent.

```php
    'facebook' => [
        'client_id' => env('FACEBOOK_KEY'),
        'client_secret' => env('FACEBOOK_SECRET'),
        'redirect' => '/verifications/facebook/callback',
    ],

    'facebook_poster' => [
        'app_id' => env('FACEBOOK_KEY'),
        'app_secret' => env('FACEBOOK_SECRET'),
        'access_token' => env('FACEBOOK_ACCESS_TOKEN'),
    ],
```