### PR TITLE
Break out base attachment class

### DIFF
--- a/src/Attachments/Attachment.php
+++ b/src/Attachments/Attachment.php
@@ -65,4 +65,3 @@ abstract class Attachment
         return [];
     }
 }
-

--- a/src/Attachments/Attachment.php
+++ b/src/Attachments/Attachment.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace NotificationChannels\FacebookPoster\Attachments;
+
+abstract class Attachment
+{
+    /**
+     * The attachment path.
+     *
+     * @var string
+     */
+    protected $path;
+
+    /**
+     * The attachment API endpoint.
+     *
+     * @var string
+     */
+    protected $apiEndpoint;
+
+    /**
+     * The attachment API method.
+     *
+     * @var string
+     */
+    protected $apiMethod = null;
+
+    /**
+     * Get the attachment path.
+     *
+     * @return string
+     */
+    public function getPath()
+    {
+        return $this->path;
+    }
+
+    /**
+     * Get the attachment API endpoint.
+     *
+     * @return string
+     */
+    public function getApiEndpoint()
+    {
+        return $this->apiEndpoint;
+    }
+
+    /**
+     * Get the attachment API method.
+     *
+     * @return string
+     */
+    public function getApiMethod()
+    {
+        return $this->apiMethod;
+    }
+
+    /**
+     * Get additional attachment data.
+     *
+     * @return array
+     */
+    public function getData()
+    {
+        return [];
+    }
+}
+

--- a/src/Attachments/Image.php
+++ b/src/Attachments/Image.php
@@ -15,7 +15,7 @@ class Image extends Attachment
      * Create a new image instance.
      *
      * @param  string  $path
-     * @param  string  $endpoint
+     * @param  string  $apiEndpoint
      */
     public function __construct($path, $apiEndpoint)
     {

--- a/src/Attachments/Image.php
+++ b/src/Attachments/Image.php
@@ -2,62 +2,24 @@
 
 namespace NotificationChannels\FacebookPoster\Attachments;
 
-class Image
+class Image extends Attachment
 {
-    /**
-     * The image path.
-     *
-     * @var string
-     */
-    protected $path;
-
-    /**
-     * The image API endpoint.
-     *
-     * @var string
-     */
-    protected $apiEndpoint;
-
     /**
      * The image API method.
      *
      * @var string
      */
-    protected $method = 'fileToUpload';
+    protected $apiMethod = 'fileToUpload';
 
     /**
      * Create a new image instance.
      *
      * @param  string  $path
-     * @param  string  $apiEndpoint
+     * @param  string  $endpoint
      */
     public function __construct($path, $apiEndpoint)
     {
         $this->path = $path;
         $this->apiEndpoint = $apiEndpoint;
-    }
-
-    /**
-     * @return string
-     */
-    public function getPath()
-    {
-        return $this->path;
-    }
-
-    /**
-     * @return string
-     */
-    public function getApiEndpoint()
-    {
-        return $this->apiEndpoint;
-    }
-
-    /**
-     * @return string
-     */
-    public function getMethod()
-    {
-        return $this->method;
     }
 }

--- a/src/Attachments/Video.php
+++ b/src/Attachments/Video.php
@@ -32,9 +32,8 @@ class Video extends Attachment
      * @param  string  $title
      * @param  string  $description
      * @param  string  $apiEndpoint
-     * @return void
      */
-    public function __construct($path, $title = null, $description = null, $apiEndpoint)
+    public function __construct($path, $title, $description, $apiEndpoint)
     {
         $this->path = $path;
         $this->title = $title;

--- a/src/Attachments/Video.php
+++ b/src/Attachments/Video.php
@@ -2,83 +2,56 @@
 
 namespace NotificationChannels\FacebookPoster\Attachments;
 
-class Video
+class Video extends Attachment
 {
-    /** @var array */
-    protected $data = [];
-
-    /** @var string */
-    protected $path;
-
-    /** @var string */
-    protected $method = 'videoToUpload';
-
-    /** @var string */
-    protected $apiEndpoint;
-
     /**
-     * @param string $videoPath
-     * @param string $endpoint
-     */
-    public function __construct($videoPath, $endpoint)
-    {
-        $this->path = $videoPath;
-        $this->apiEndpoint = $endpoint;
-    }
-
-    /**
-     * @param $title
+     * The video title.
      *
-     * @return $this
+     * @var string
      */
-    public function setTitle($title)
-    {
-        $this->data['title'] = $title;
-
-        return $this;
-    }
+    protected $title;
 
     /**
-     * @param string $description
+     * The video description.
      *
-     * @return $this
+     * @var string
      */
-    public function setDescription($description)
-    {
-        $this->data['description'] = $description;
+    protected $description;
 
-        return $this;
+    /**
+     * The video API method.
+     *
+     * @var string
+     */
+    protected $apiMethod = 'videoToUpload';
+
+    /**
+     * Create a new video instance.
+     *
+     * @param  string  $path
+     * @param  string  $title
+     * @param  string  $description
+     * @param  string  $apiEndpoint
+     * @return void
+     */
+    public function __construct($path, $title = null, $description = null, $apiEndpoint)
+    {
+        $this->path = $path;
+        $this->title = $title;
+        $this->description = $description;
+        $this->apiEndpoint = $apiEndpoint;
     }
 
     /**
+     * Get additional attachment data.
+     *
      * @return array
      */
     public function getData()
     {
-        return $this->data;
-    }
-
-    /**
-     * @return string
-     */
-    public function getPath()
-    {
-        return $this->path;
-    }
-
-    /**
-     * @return string
-     */
-    public function getApiEndpoint()
-    {
-        return $this->apiEndpoint;
-    }
-
-    /**
-     * @return string
-     */
-    public function getMethod()
-    {
-        return $this->method;
+        return array_filter([
+            'title' => $this->title,
+            'description' => $this->description,
+        ]);
     }
 }

--- a/src/FacebookPosterChannel.php
+++ b/src/FacebookPosterChannel.php
@@ -4,7 +4,6 @@ namespace NotificationChannels\FacebookPoster;
 
 use Facebook\Facebook;
 use Illuminate\Notifications\Notification;
-use NotificationChannels\FacebookPoster\Attachments\Video;
 use NotificationChannels\FacebookPoster\Exceptions\InvalidPostContent;
 
 class FacebookPosterChannel
@@ -42,15 +41,12 @@ class FacebookPosterChannel
 
         $this->guardAgainstInvalidPostContent($postBody);
 
-        // here we check if post body has image or video to upload it first to facebook
         if (isset($postBody['media'])) {
             $endpoint = $postBody['media']->getApiEndpoint();
 
-            if ($postBody['media'] instanceof Video) {
-                $postBody = array_merge($postBody, $postBody['media']->getData());
-            }
+            $postBody = array_merge($postBody, $postBody['media']->getData());
 
-            $method = $postBody['media']->getMethod();
+            $method = $postBody['media']->getApiMethod();
 
             $postBody['source'] = $this->facebook->{$method}($postBody['media']->getPath());
 

--- a/src/FacebookPosterPost.php
+++ b/src/FacebookPosterPost.php
@@ -87,48 +87,37 @@ class FacebookPosterPost
     }
 
     /**
-     * Set facebook post image.
+     * Set a post image.
      *
-     * @param $imagePath
-     * @param string $endpoint
-     *
+     * @param  string  $path
+     * @param  string  $endpoint
      * @return $this
      */
-    public function withImage($imagePath, $endpoint = 'me/photos')
+    public function withImage($path, $endpoint = 'me/photos')
     {
-        $this->image = new Image($imagePath, $endpoint);
+        $this->image = new Image($path, $endpoint);
 
         return $this;
     }
 
     /**
-     * Set facebook post image.
+     * Set a post video.
      *
-     * @param $videoPath
-     * @param array  $data
-     * @param string $endpoint
-     *
+     * @param  string  $path
+     * @param  string  $title
+     * @param  string  $description
+     * @param  string  $endpoint
      * @return $this
      */
-    public function withVideo($videoPath, $data = [], $endpoint = 'me/videos')
+    public function withVideo($path, $title = null, $description = null, $endpoint = 'me/videos')
     {
-        $this->video = new Video($videoPath, $endpoint);
-
-        if (isset($data['title'])) {
-            $this->video->setTitle($data['title']);
-        }
-
-        if (isset($data['description'])) {
-            $this->video->setDescription($data['description']);
-        }
+        $this->video = new Video($path, $title, $description, $endpoint);
 
         return $this;
     }
 
     /**
      * Schedule the post for a date in the future.
-     *
-     * @param string $timestamp UNIX timestamp
      *
      * @param  \DateTimeInterface|int  $timestamp
      * @return $this

--- a/src/FacebookPosterPost.php
+++ b/src/FacebookPosterPost.php
@@ -26,14 +26,14 @@ class FacebookPosterPost
     /**
      * The post image.
      *
-     * @var \NotificationChannels\FacebookPoster\Image
+     * @var \NotificationChannels\FacebookPoster\Attachments\Image
      */
     protected $image;
 
     /**
      * The post video.
      *
-     * @var \NotificationChannels\FacebookPoster\Video
+     * @var \NotificationChannels\FacebookPoster\Attachments\Video
      */
     protected $video;
 

--- a/tests/Attachments/ImageTest.php
+++ b/tests/Attachments/ImageTest.php
@@ -40,7 +40,7 @@ class ImageTest extends TestCase
     {
         $image = new Image('path', 'endpoint');
 
-        $result = $image->getMethod();
+        $result = $image->getApiMethod();
 
         $this->assertEquals('fileToUpload', $result);
     }

--- a/tests/FacebookPosterChannelTest.php
+++ b/tests/FacebookPosterChannelTest.php
@@ -27,7 +27,7 @@ class FacebookPosterChannelTest extends TestCase
     {
         $this->facebook->shouldReceive('post')->once()->with(
             'me/feed',
-            ['message' => 'Laravel Notification Channels are awesome!']
+            ['message' => 'message']
         );
 
         $this->channel->send(new TestNotifiable(), new TestNotification());
@@ -38,7 +38,7 @@ class FacebookPosterChannelTest extends TestCase
     {
         $this->facebook->shouldReceive('post')->once()->with(
             'me/feed',
-            ['message' => 'Laravel Notification Channels are awesome!', 'link' => 'http://laravel.com']
+            ['message' => 'message', 'link' => 'http://laravel.com']
         );
 
         $this->channel->send(new TestNotifiable(), new TestNotificationWithLink());
@@ -47,7 +47,10 @@ class FacebookPosterChannelTest extends TestCase
     /** @test */
     public function it_can_send_a_post_with_image()
     {
-        $this->facebook->shouldReceive('post')->once()->with('me/photos', ['message' => 'Laravel Notification Channels are awesome!', 'source' => null]);
+        $this->facebook->shouldReceive('post')->once()->with('me/photos', [
+            'source' => null,
+            'message' => 'message',
+        ]);
 
         $this->facebook->shouldReceive('fileToUpload')->once()->with('image1.png');
 
@@ -57,7 +60,12 @@ class FacebookPosterChannelTest extends TestCase
     /** @test */
     public function it_can_send_a_post_with_video()
     {
-        $this->facebook->shouldReceive('post')->once()->with('me/videos', ['message' => 'Laravel Notification Channels are awesome!', 'source' => null, 'title' => 'laravel', 'description' => 'laravel framework.']);
+        $this->facebook->shouldReceive('post')->once()->with('me/videos', [
+            'source' => null,
+            'title' => 'title',
+            'description' => 'description',
+            'message' => 'message',
+        ]);
 
         $this->facebook->shouldReceive('videoToUpload')->once()->with('video1.mp4');
 

--- a/tests/TestNotification.php
+++ b/tests/TestNotification.php
@@ -9,6 +9,6 @@ class TestNotification extends Notification
 {
     public function toFacebookPoster($notifiable)
     {
-        return new FacebookPosterPost('Laravel Notification Channels are awesome!');
+        return new FacebookPosterPost('message');
     }
 }

--- a/tests/TestNotificationWithImage.php
+++ b/tests/TestNotificationWithImage.php
@@ -9,7 +9,7 @@ class TestNotificationWithImage extends Notification
 {
     public function toFacebookPoster($notifiable)
     {
-        return (new FacebookPosterPost('Laravel Notification Channels are awesome!'))
+        return (new FacebookPosterPost('message'))
             ->withImage('image1.png');
     }
 }

--- a/tests/TestNotificationWithLink.php
+++ b/tests/TestNotificationWithLink.php
@@ -9,7 +9,7 @@ class TestNotificationWithLink extends Notification
 {
     public function toFacebookPoster($notifiable)
     {
-        return (new FacebookPosterPost('Laravel Notification Channels are awesome!'))
+        return (new FacebookPosterPost('message'))
             ->withLink('http://laravel.com');
     }
 }

--- a/tests/TestNotificationWithVideo.php
+++ b/tests/TestNotificationWithVideo.php
@@ -9,7 +9,7 @@ class TestNotificationWithVideo extends Notification
 {
     public function toFacebookPoster($notifiable)
     {
-        return (new FacebookPosterPost('Laravel Notification Channels are awesome!'))
-            ->withVideo('video1.mp4', ['title' => 'laravel', 'description' => 'laravel framework.']);
+        return (new FacebookPosterPost('message'))
+            ->withVideo('video1.mp4', 'title', 'description');
     }
 }


### PR DESCRIPTION
The structure of the attachments is a little messy, with a bit of duplication. It's also a little odd that the channel needs to determine whether it's a video or not before making a call on it, so we'll just make it part of the "interface". This is still a work in progress to clean up the "post" classes.

I've also simplified the content of tests so it's easier to identify what's going on.